### PR TITLE
UC09 - Functie: Productenlijst exporteren naar JSON

### DIFF
--- a/Grocery.App/Views/ProductView.xaml
+++ b/Grocery.App/Views/ProductView.xaml
@@ -4,7 +4,9 @@
              xmlns:vm="clr-namespace:Grocery.App.ViewModels"
              x:Class="Grocery.App.Views.ProductView"
              Title="ProductView">
-    
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Export de producten lijst" Command="{Binding ExportProductsListAsJsonCommand}"  IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
+    </ContentPage.ToolbarItems>
     <Shell.TitleView>
         <Grid>
             <Label Text="Producten" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />

--- a/TestCore/TestExportProductsAsJSON.cs
+++ b/TestCore/TestExportProductsAsJSON.cs
@@ -1,0 +1,91 @@
+﻿using System.Text.Json;
+using TestCore.ViewModels;
+using Grocery.Core.Interfaces.Services;
+using Grocery.Core.Models;
+using Moq;
+
+namespace TestCore
+{
+    [TestFixture]
+    public class TestExportProductsAsJSON
+    {
+        private Mock<IProductService> _productService;
+        private Mock<IFileSaverService> _fileSaver;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _productService = new Mock<IProductService>();
+            _fileSaver = new Mock<IFileSaverService>();
+        }
+
+        [Test]
+        public async Task ExportProductsListAsJson_SavesSerializedProducts_WithExpectedFileName()
+        {
+            // Arrange
+            var products = new List<Product>
+            {
+                new Product(1, "Appel", 10),
+                new Product(2, "Banaan", 0)
+            };
+            _productService.Setup(s => s.GetAll()).Returns(products);
+
+                var vm = new TestExportProductsToJSONViewModel(_productService.Object, _fileSaver.Object);
+                var token = CancellationToken.None;
+                var expectedJson = JsonSerializer.Serialize(vm.Products);
+
+            // Act
+            await vm.ExportProductsListAsJson(token);
+
+            // Assert
+            _fileSaver.Verify(s => s.SaveFileAsync(
+                "Producten.json",
+                expectedJson,
+                token),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task ExportProductsListAsJson_WhenProductsIsNull_DoesNotCallFileSaver()
+        {
+            // Arrange
+            _productService.Setup(s => s.GetAll()).Returns(new List<Product>());
+            var vm = new TestExportProductsToJSONViewModel(_productService.Object, _fileSaver.Object)
+            {
+                Products = null!
+            };
+
+            // Act
+            await vm.ExportProductsListAsJson(CancellationToken.None);
+
+            // Assert
+            _fileSaver.Verify(s => s.SaveFileAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Test]
+        public async Task ExportProductsListAsJson_WhenSaveThrows_MethodDoesNotThrow()
+        {
+            // Arrange
+            var products = new List<Product> { new Product(1, "Appel", 10) };
+            _productService.Setup(s => s.GetAll()).Returns(products);
+
+            _fileSaver
+                .Setup(s => s.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new System.Exception("IO error"));
+
+            var vm = new TestExportProductsToJSONViewModel(_productService.Object, _fileSaver.Object);
+
+            // Act & Assert (no exception should escape)
+            Assert.DoesNotThrowAsync(async () => await vm.ExportProductsListAsJson(CancellationToken.None));
+            _fileSaver.Verify(s => s.SaveFileAsync(
+                "Producten.json",
+                It.Is<string>(json => !string.IsNullOrWhiteSpace(json)),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}

--- a/TestCore/ViewModels/TestExportProductsToJSONViewModel.cs
+++ b/TestCore/ViewModels/TestExportProductsToJSONViewModel.cs
@@ -1,28 +1,22 @@
-﻿using CommunityToolkit.Maui.Alerts;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
+﻿using CommunityToolkit.Mvvm.Input;
 using Grocery.Core.Interfaces.Services;
 using Grocery.Core.Models;
-using Grocery.Core.Services;
 using System.Collections.ObjectModel;
-using System.Reflection.Metadata;
 using System.Text.Json;
-using System.Windows.Input;
 
-namespace Grocery.App.ViewModels
+namespace TestCore.ViewModels
 {
-    public partial class ProductViewModel : BaseViewModel
+    public partial class TestExportProductsToJSONViewModel
     {
         private readonly IFileSaverService _fileSaverService;
 
         public ObservableCollection<Product> Products { get; set; }
 
-        public ProductViewModel(IProductService productService, IFileSaverService fileSaverService)
+        public TestExportProductsToJSONViewModel(IProductService productService, IFileSaverService fileSaverService)
         {
             Products = new(productService.GetAll());
             _fileSaverService = fileSaverService;
         }
-
 
         [RelayCommand]
         public async Task ExportProductsListAsJson(CancellationToken cancellationToken)
@@ -32,13 +26,11 @@ namespace Grocery.App.ViewModels
             try
             {
                 await _fileSaverService.SaveFileAsync("Producten.json", jsonString, cancellationToken);
-                await Toast.Make("Productenlijst is opgeslagen.").Show(cancellationToken);
             }
             catch (Exception ex)
             {
-                await Toast.Make($"Opslaan mislukt: {ex.Message}").Show(cancellationToken);
+                System.Diagnostics.Debug.WriteLine($"Opslaan mislukt: {ex.Message}");
             }
         }
-
     }
 }


### PR DESCRIPTION
Er is functionaliteit toegevoegd om de productenlijst te exporteren als een JSON-bestand. ProductViewModel is uitgebreid met de methode ExportProductsListAsJson, die IFileSaverService gebruikt om het bestand op te slaan en toastmeldingen toont voor feedback. ProductView.xaml heeft een nieuw toolbar-item gekregen dat de export activeert. De test TestExportProductsAsJSON.cs is toegevoegd om de export te verifiëren: succesvol opslaan, null-productlijst, en excepties tijdens het opslaan. De TestExportProductsToJSONViewModel is toegevoegd voor testspecifieke logica. ProductViewModel is gerefactord voor betere dependency injection en modulariteit door IFileSaverService te introduceren. CommunityToolkit-bibliotheken zijn toegevoegd voor MVVM-ondersteuning en toastmeldingen.